### PR TITLE
🧹 [コードヘルスの改善] サムネイル作成時の空のcatchブロックにログ出力を追加

### DIFF
--- a/MediaDeck.FileTypes/Archive/Models/ArchiveFileOperator.cs
+++ b/MediaDeck.FileTypes/Archive/Models/ArchiveFileOperator.cs
@@ -9,14 +9,18 @@ using MediaDeck.Database.Tables;
 using MediaDeck.FileTypes.Base.Models;
 using MediaDeck.FileTypes.Image.Utils;
 
+using Microsoft.Extensions.Logging;
+
 namespace MediaDeck.FileTypes.Archive.Models;
 
 [Inject(InjectServiceLifetime.Transient)]
 internal partial class ArchiveFileOperator : BaseFileOperator {
 	private readonly IFilePathService _filePathService;
+	private readonly ILogger<ArchiveFileOperator> _logger;
 
-	public ArchiveFileOperator(IFilePathService filePathService) : base(MediaType.Archive) {
+	public ArchiveFileOperator(IFilePathService filePathService, ILogger<ArchiveFileOperator> logger) : base(MediaType.Archive) {
 		this._filePathService = filePathService;
+		this._logger = logger;
 	}
 
 	public override async Task<MediaFile?> RegisterFileAsync(string filePath) {
@@ -38,7 +42,8 @@ internal partial class ArchiveFileOperator : BaseFileOperator {
 				new FileInfo(thumbPath).Directory?.Create();
 				File.WriteAllBytes(thumbPath, image);
 			}
-		} catch (Exception) {
+		} catch (Exception ex) {
+			this._logger.LogError(ex, "Failed to create archive thumbnail for file {FilePath}", filePath);
 			thumbPath = null;
 			thumbRelativePath = null;
 		}
@@ -70,7 +75,8 @@ internal partial class ArchiveFileOperator : BaseFileOperator {
 				using var meta = ImageMetadataFactory.Create(ms);
 				mf.Width = meta.Width;
 				mf.Height = meta.Height;
-			} catch (Exception) {
+			} catch (Exception ex) {
+				this._logger.LogError(ex, "Failed to get image metadata for archive entry {EntryName} in file {FilePath}", first.FullName, filePath);
 				mf.Width = 0;
 				mf.Height = 0;
 			}

--- a/MediaDeck.FileTypes/Archive/ViewModels/ArchiveThumbnailPickerViewModel.cs
+++ b/MediaDeck.FileTypes/Archive/ViewModels/ArchiveThumbnailPickerViewModel.cs
@@ -1,6 +1,8 @@
 using System.IO.Compression;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
+
 using MediaDeck.Composition.Interfaces.FileTypes.ViewModels;
 using MediaDeck.FileTypes.Archive.Models;
 using MediaDeck.FileTypes.Base.Models;
@@ -12,10 +14,12 @@ namespace MediaDeck.FileTypes.Archive.ViewModels;
 internal class ArchiveThumbnailPickerViewModel : BaseThumbnailPickerViewModel {
 	private readonly ArchiveFileOperator _archiveFileOperator;
 	private readonly IFilePathService _filePathService;
+	private readonly ILogger<ArchiveThumbnailPickerViewModel> _logger;
 
-	public ArchiveThumbnailPickerViewModel(BaseThumbnailPickerModel thumbnailPickerModel, ArchiveFileOperator pdfFileOperator, IFilePathService filePathService) : base(thumbnailPickerModel) {
+	public ArchiveThumbnailPickerViewModel(BaseThumbnailPickerModel thumbnailPickerModel, ArchiveFileOperator pdfFileOperator, IFilePathService filePathService, ILogger<ArchiveThumbnailPickerViewModel> logger) : base(thumbnailPickerModel) {
 		this._archiveFileOperator = pdfFileOperator;
 		this._filePathService = filePathService;
+		this._logger = logger;
 		this.SelectedEntry.Subscribe(x => {
 			if (x is null) {
 				this.FileName.Value = null;
@@ -54,7 +58,8 @@ internal class ArchiveThumbnailPickerViewModel : BaseThumbnailPickerViewModel {
 
 		try {
 			this.CandidateThumbnail.Value = this._archiveFileOperator.CreateThumbnail(archive, 300, 300, this.FileName.Value);
-		} catch (Exception) {
+		} catch (Exception ex) {
+			this._logger.LogError(ex, "Failed to recreate archive thumbnail for file {FilePath} at entry {EntryName}", this.targetFileViewModel.FilePath, this.FileName.Value);
 			this.CandidateThumbnail.Value = null;
 		}
 	}

--- a/MediaDeck.FileTypes/Pdf/Models/PdfFileOperator.cs
+++ b/MediaDeck.FileTypes/Pdf/Models/PdfFileOperator.cs
@@ -6,6 +6,8 @@ using MediaDeck.Composition.Enum;
 using MediaDeck.Database.Tables;
 using MediaDeck.FileTypes.Base.Models;
 
+using Microsoft.Extensions.Logging;
+
 using Patagames.Pdf.Enums;
 using Patagames.Pdf.Net;
 
@@ -14,9 +16,11 @@ namespace MediaDeck.FileTypes.Pdf.Models;
 [Inject(InjectServiceLifetime.Transient)]
 internal partial class PdfFileOperator : BaseFileOperator {
 	private readonly IFilePathService _filePathService;
+	private readonly ILogger<PdfFileOperator> _logger;
 
-	public PdfFileOperator(IFilePathService filePathService) : base(MediaType.Pdf) {
+	public PdfFileOperator(IFilePathService filePathService, ILogger<PdfFileOperator> logger) : base(MediaType.Pdf) {
 		this._filePathService = filePathService;
+		this._logger = logger;
 	}
 
 	public override async Task<MediaFile?> RegisterFileAsync(string filePath) {
@@ -33,7 +37,8 @@ internal partial class PdfFileOperator : BaseFileOperator {
 			var image = this.CreateThumbnail(filePath, 300, 300, 1);
 			new FileInfo(thumbPath).Directory?.Create();
 			File.WriteAllBytes(thumbPath, image);
-		} catch (Exception) {
+		} catch (Exception ex) {
+			this._logger.LogError(ex, "Failed to create pdf thumbnail for file {FilePath}", filePath);
 			thumbPath = null;
 			thumbRelativePath = null;
 		}

--- a/MediaDeck.FileTypes/Pdf/ViewModels/PdfThumbnailPickerViewModel.cs
+++ b/MediaDeck.FileTypes/Pdf/ViewModels/PdfThumbnailPickerViewModel.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 using MediaDeck.FileTypes.Base.Models;
 using MediaDeck.FileTypes.Base.ViewModels;
 using MediaDeck.FileTypes.Pdf.Models;
@@ -5,8 +7,9 @@ using MediaDeck.FileTypes.Pdf.Models;
 namespace MediaDeck.FileTypes.Pdf.ViewModels;
 
 [Inject(InjectServiceLifetime.Transient)]
-internal class PdfThumbnailPickerViewModel(BaseThumbnailPickerModel thumbnailPickerModel, PdfFileOperator pdfFileOperator) : BaseThumbnailPickerViewModel(thumbnailPickerModel) {
+internal class PdfThumbnailPickerViewModel(BaseThumbnailPickerModel thumbnailPickerModel, PdfFileOperator pdfFileOperator, ILogger<PdfThumbnailPickerViewModel> logger) : BaseThumbnailPickerViewModel(thumbnailPickerModel) {
 	private readonly PdfFileOperator _pdfFileOperator = pdfFileOperator;
+	private readonly ILogger<PdfThumbnailPickerViewModel> _logger = logger;
 
 	internal BindableReactiveProperty<int> PageNumber {
 		get;
@@ -18,7 +21,8 @@ internal class PdfThumbnailPickerViewModel(BaseThumbnailPickerModel thumbnailPic
 		}
 		try {
 			this.CandidateThumbnail.Value = this._pdfFileOperator.CreateThumbnail(this.targetFileViewModel.FilePath, 300, 300, this.PageNumber.Value);
-		} catch (Exception) {
+		} catch (Exception ex) {
+			this._logger.LogError(ex, "Failed to recreate pdf thumbnail for file {FilePath} at page {PageNumber}", this.targetFileViewModel.FilePath, this.PageNumber.Value);
 			this.CandidateThumbnail.Value = null;
 		}
 	}

--- a/MediaDeck.FileTypes/Video/Models/VideoFileOperator.cs
+++ b/MediaDeck.FileTypes/Video/Models/VideoFileOperator.cs
@@ -12,6 +12,8 @@ using MediaDeck.Composition.Interfaces.FileTypes.Models;
 using MediaDeck.Composition.Stores.Config.Model;
 using MediaDeck.Database.Tables;
 using MediaDeck.Database.Tables.Metadata;
+using Microsoft.Extensions.Logging;
+
 using MediaDeck.FileTypes.Base.Models;
 
 namespace MediaDeck.FileTypes.Video.Models;
@@ -20,15 +22,17 @@ namespace MediaDeck.FileTypes.Video.Models;
 internal partial class VideoFileOperator : BaseFileOperator {
 	private readonly ConfigModel _config;
 	private readonly IFilePathService _filePathService;
+	private readonly ILogger<VideoFileOperator> _logger;
 
 	private static readonly string[] locationTagNames = [
 		"TAG:location",
 		"TAG:com.apple.quicktime.location.ISO6709"
 	];
 
-	public VideoFileOperator(IFilePathService filePathService) : base(MediaType.Video) {
+	public VideoFileOperator(IFilePathService filePathService, ILogger<VideoFileOperator> logger) : base(MediaType.Video) {
 		this._config = Ioc.Default.GetRequiredService<ConfigModel>();
 		this._filePathService = filePathService;
+		this._logger = logger;
 	}
 
 	public override async Task<MediaFile?> RegisterFileAsync(string filePath) {
@@ -49,7 +53,8 @@ internal partial class VideoFileOperator : BaseFileOperator {
 			var image = this.CreateThumbnail(filePath, videoStream.Width, videoStream.Height, 300, 300, metadata.Duration / 5);
 			new FileInfo(thumbPath).Directory?.Create();
 			File.WriteAllBytes(thumbPath, image);
-		} catch (Exception) {
+		} catch (Exception ex) {
+			this._logger.LogError(ex, "Failed to create video thumbnail for file {FilePath}", filePath);
 			thumbPath = null;
 			thumbRelativePath = null;
 		}

--- a/MediaDeck.FileTypes/Video/ViewModels/VideoThumbnailPickerViewModel.cs
+++ b/MediaDeck.FileTypes/Video/ViewModels/VideoThumbnailPickerViewModel.cs
@@ -1,5 +1,7 @@
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
+
 using MediaDeck.Composition.Interfaces.FileTypes.ViewModels;
 using MediaDeck.FileTypes.Base.Models;
 using MediaDeck.FileTypes.Base.ViewModels;
@@ -11,12 +13,16 @@ namespace MediaDeck.FileTypes.Video.ViewModels;
 internal class VideoThumbnailPickerViewModel : BaseThumbnailPickerViewModel {
 	public VideoThumbnailPickerViewModel(
 		BaseThumbnailPickerModel thumbnailPickerModel,
-		VideoFileOperator videoFileOperator) : base(thumbnailPickerModel) {
+		VideoFileOperator videoFileOperator,
+		ILogger<VideoThumbnailPickerViewModel> logger) : base(thumbnailPickerModel) {
 		this._videoFileOperator = videoFileOperator;
+		this._logger = logger;
 		this._updateTimeSubject.ObserveOnCurrentSynchronizationContext().Subscribe(x => this.Time.Value = x);
 	}
 
 	private readonly VideoFileOperator _videoFileOperator;
+
+	private readonly ILogger<VideoThumbnailPickerViewModel> _logger;
 
 	private readonly Subject<TimeSpan> _updateTimeSubject = new();
 
@@ -34,7 +40,8 @@ internal class VideoThumbnailPickerViewModel : BaseThumbnailPickerViewModel {
 		}
 		try {
 			this.CandidateThumbnail.Value = this._videoFileOperator.CreateThumbnail(this.targetFileViewModel.FileModel, 300, 300, this.Time.Value);
-		} catch (Exception) {
+		} catch (Exception ex) {
+			this._logger.LogError(ex, "Failed to recreate video thumbnail for file {FilePath}", this.targetFileViewModel.FilePath);
 			this.CandidateThumbnail.Value = null;
 		}
 	}


### PR DESCRIPTION
🎯 **内容:** 解決したコードヘルスの問題
- ビデオ、PDF、アーカイブ（Zip）の各ファイル形式において、サムネイル作成やメタデータ抽出のロジックで例外が握りつぶされていた箇所にログ出力を追加しました。
- 3つの ViewModel と 3つの Operator に `ILogger<T>` を導入し、例外発生時にスタックトレースとファイルパスなどのコンテキスト情報を記録するようにしました。

💡 **理由:** 保守性の向上
- これまではサムネイル作成に失敗しても理由が不明でしたが、今回の修正によりログから失敗の原因を特定できるようになります。
- ユーザーの要望通り、例外をキャッチして処理を継続する挙動は維持しているため、サムネイル作成に失敗してもファイル自体の登録（DBレコード作成）は正常に行われます。

✅ **検証:** 変更の安全性確認
- 修正した6つのファイルすべてについて、入念なコードレビューを実施しました。
- ロジックの流れ（例外をキャッチしてデフォルト値を返す）が変わっていないことを確認しました。
- `AutoDiAttributes` (`[Inject]`) による依存性注入が、プロジェクトの既存パターン（`BaseThumbnailPickerModel.cs` など）と一致していることを確認しました。

✨ **結果:** 達成された改善
- 複数のメディアタイプにおけるサムネイル生成サブシステムの観測可能性とデバッグのしやすさが向上しました。

---
*PR created automatically by Jules for task [16787100738383592825](https://jules.google.com/task/16787100738383592825) started by @xm-i*