### PR TITLE
🧪 [testing] add FileChangeItem unit tests

### DIFF
--- a/MediaDeck.Core.Tests/Models/Services/FileChangeItemTests.cs
+++ b/MediaDeck.Core.Tests/Models/Services/FileChangeItemTests.cs
@@ -1,0 +1,110 @@
+using System;
+using MediaDeck.Core.Models.Services;
+using Xunit;
+
+namespace MediaDeck.Core.Tests.Models.Services;
+
+/// <summary>
+/// <see cref="FileChangeItem"/> のテストクラスです。
+/// </summary>
+public class FileChangeItemTests {
+    /// <summary>
+    /// デフォルト値が正しく設定されているかをテストします。
+    /// </summary>
+    [Fact]
+    public void DefaultConstructor_SetsExpectedDefaultValues() {
+        // Arrange & Act
+        var item = new FileChangeItem();
+
+        // Assert
+        Assert.Null(item.MediaFileId);
+
+        // CreatedAt は現在時刻に近い値であることを確認
+        var timeDifference = DateTime.UtcNow - item.CreatedAt;
+        Assert.True(timeDifference.TotalSeconds < 1, "CreatedAt が現在時刻に近い値ではありません");
+
+        Assert.False(item.IsPending);
+        Assert.Equal(string.Empty, item.OldPath);
+        Assert.Equal(string.Empty, item.NewPath);
+        Assert.Equal(default(FileChangeType), item.ChangeType);
+        Assert.False(item.IsHashing);
+        Assert.Equal(0, item.FileSize);
+        Assert.Equal(string.Empty, item.OldHash);
+        Assert.Equal(string.Empty, item.NewHash);
+
+        // デフォルトの ChangeType は 0 (Deleted) になるため、対応するテキストを検証
+        Assert.Equal("削除", item.ChangeTypeText);
+    }
+
+    /// <summary>
+    /// 各プロパティの Get/Set が正しく動作するかをテストします。
+    /// </summary>
+    [Fact]
+    public void Properties_CanBeSetAndRetrieved() {
+        // Arrange
+        var item = new FileChangeItem();
+        var now = DateTime.UtcNow;
+
+        // Act
+        item.MediaFileId = 123;
+        item.CreatedAt = now;
+        item.IsPending = true;
+        item.OldPath = "C:\\old\\path.txt";
+        item.NewPath = "C:\\new\\path.txt";
+        item.ChangeType = FileChangeType.Moved;
+        item.IsHashing = true;
+        item.FileSize = 1024;
+        item.OldHash = "oldhash";
+        item.NewHash = "newhash";
+
+        // Assert
+        Assert.Equal(123, item.MediaFileId);
+        Assert.Equal(now, item.CreatedAt);
+        Assert.True(item.IsPending);
+        Assert.Equal("C:\\old\\path.txt", item.OldPath);
+        Assert.Equal("C:\\new\\path.txt", item.NewPath);
+        Assert.Equal(FileChangeType.Moved, item.ChangeType);
+        Assert.True(item.IsHashing);
+        Assert.Equal(1024, item.FileSize);
+        Assert.Equal("oldhash", item.OldHash);
+        Assert.Equal("newhash", item.NewHash);
+    }
+
+    /// <summary>
+    /// <see cref="FileChangeType"/> に応じて正しい <see cref="FileChangeItem.ChangeTypeText"/> が返されるかをテストします。
+    /// </summary>
+    [Theory]
+    [InlineData(FileChangeType.Deleted, "削除")]
+    [InlineData(FileChangeType.Renamed, "変更")]
+    [InlineData(FileChangeType.Moved, "移動")]
+    [InlineData(FileChangeType.Added, "追加")]
+    public void ChangeTypeText_ReturnsExpectedText(FileChangeType changeType, string expectedText) {
+        // Arrange
+        var item = new FileChangeItem {
+            ChangeType = changeType
+        };
+
+        // Act
+        var result = item.ChangeTypeText;
+
+        // Assert
+        Assert.Equal(expectedText, result);
+    }
+
+    /// <summary>
+    /// 定義されていない <see cref="FileChangeType"/> の場合、"不明" が返されるかをテストします。
+    /// </summary>
+    [Fact]
+    public void ChangeTypeText_WithInvalidChangeType_ReturnsUnknown() {
+        // Arrange
+        var item = new FileChangeItem {
+            ChangeType = (FileChangeType)999
+        };
+
+        // Act
+        var result = item.ChangeTypeText;
+
+        // Assert
+        Assert.Equal("不明", result);
+    }
+}


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the `FileChangeItem` model in the `MediaDeck.Core` project to address missing test coverage.

📊 **Coverage:** 
The new tests cover the following scenarios:
- **Initialization:** Verification that the default constructor initializes properties correctly (e.g., `CreatedAt` is set to UTC now, initial paths/hashes are empty strings).
- **Property Mutations:** Validating that all property setters and getters work properly.
- **Derived Properties:** Ensuring that the `ChangeTypeText` string property computes appropriately according to the corresponding `FileChangeType` enum values (`Deleted`, `Renamed`, `Moved`, `Added`, or unknown).

✨ **Result:** 
Improved codebase reliability by securing the structure and logic of the `FileChangeItem` model against unintentional regressions. Allowed the model's computed switch properties to be verified via `[Theory]` driven `[InlineData]` tests. All newly added unit tests passed locally.

---
*PR created automatically by Jules for task [8421482383553160658](https://jules.google.com/task/8421482383553160658) started by @xm-i*