### PR TITLE
🔒 [Security] 外部プロセス起動のセキュリティ強化 (ShellExecuteExWの削除)

### DIFF
--- a/MediaDeck.Common/Utilities/ShellUtility.cs
+++ b/MediaDeck.Common/Utilities/ShellUtility.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace MediaDeck.Common.Utilities;
 
@@ -6,6 +8,46 @@ namespace MediaDeck.Common.Utilities;
 /// シェル連携機能を提供するユーティリティクラス
 /// </summary>
 public static class ShellUtility {
+	[DllImport("user32.dll")]
+	private static extern nint GetForegroundWindow();
+
+	[DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool ShellExecuteExW(ref SHELLEXECUTEINFOW lpExecInfo);
+
+	[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+	private struct SHELLEXECUTEINFOW {
+		public int cbSize;
+		public uint fMask;
+		public nint hwnd;
+
+		[MarshalAs(UnmanagedType.LPWStr)]
+		public string lpVerb;
+
+		[MarshalAs(UnmanagedType.LPWStr)]
+		public string lpFile;
+
+		[MarshalAs(UnmanagedType.LPWStr)]
+		public string? lpParameters;
+
+		[MarshalAs(UnmanagedType.LPWStr)]
+		public string? lpDirectory;
+
+		public int nShow;
+		public nint hInstApp;
+		public nint lpIDList;
+
+		[MarshalAs(UnmanagedType.LPWStr)]
+		public string? lpClass;
+
+		public nint hkeyClass;
+		public uint dwHotKey;
+		public nint hIcon;
+		public nint hProcess;
+	}
+
+	private const int SW_SHOWNORMAL = 1;
+
 	/// <summary>
 	/// Explorerでファイルを選択した状態で表示します
 	/// </summary>
@@ -26,18 +68,38 @@ public static class ShellUtility {
 	/// <param name="filePath">開く対象のファイルパス</param>
 	/// <param name="arguments">プログラムに渡す引数。nullの場合はファイル単体として開きます</param>
 	public static void ShellExecute(string filePath, string? arguments = null) {
-		var psi = new ProcessStartInfo {
-			UseShellExecute = false
+		if (string.IsNullOrEmpty(filePath)) return;
+
+		// セキュリティ対策:
+		// PATH上の任意の実行ファイル（cmd.exe等）やURLプロトコルの意図しない起動を防ぐため絶対パス化する
+		var fullPath = Path.GetFullPath(filePath);
+
+		var hwnd = GetForegroundWindow();
+
+		var info = new SHELLEXECUTEINFOW {
+			cbSize = Marshal.SizeOf<SHELLEXECUTEINFOW>(),
+			hwnd = hwnd,
+			lpVerb = "open",
+			lpFile = fullPath,
+			lpParameters = arguments,
+			nShow = SW_SHOWNORMAL
 		};
 
-		if (arguments != null) {
-			psi.FileName = filePath;
-			psi.Arguments = arguments;
-		} else {
-			psi.FileName = "explorer.exe";
-			psi.ArgumentList.Add(filePath);
-		}
+		if (!ShellExecuteExW(ref info)) {
+			// フォールバック: セキュアなProcess.Startを使用
+			var psi = new ProcessStartInfo {
+				UseShellExecute = false
+			};
 
-		Process.Start(psi);
+			if (arguments != null) {
+				psi.FileName = fullPath;
+				psi.Arguments = arguments;
+			} else {
+				psi.FileName = "explorer.exe";
+				psi.ArgumentList.Add(fullPath);
+			}
+
+			Process.Start(psi);
+		}
 	}
 }

--- a/MediaDeck.Common/Utilities/ShellUtility.cs
+++ b/MediaDeck.Common/Utilities/ShellUtility.cs
@@ -88,15 +88,12 @@ public static class ShellUtility {
 		if (!ShellExecuteExW(ref info)) {
 			// フォールバック: セキュアなProcess.Startを使用
 			var psi = new ProcessStartInfo {
+				FileName = fullPath,
 				UseShellExecute = false
 			};
 
 			if (arguments != null) {
-				psi.FileName = fullPath;
 				psi.Arguments = arguments;
-			} else {
-				psi.FileName = "explorer.exe";
-				psi.ArgumentList.Add(fullPath);
 			}
 
 			Process.Start(psi);

--- a/MediaDeck.Common/Utilities/ShellUtility.cs
+++ b/MediaDeck.Common/Utilities/ShellUtility.cs
@@ -1,77 +1,15 @@
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace MediaDeck.Common.Utilities;
 
+/// <summary>
+/// シェル連携機能を提供するユーティリティクラス
+/// </summary>
 public static class ShellUtility {
-	[DllImport("user32.dll")]
-	private static extern nint GetForegroundWindow();
-
-	[DllImport("shell32.dll", CharSet = CharSet.Unicode)]
-	[return: MarshalAs(UnmanagedType.Bool)]
-	private static extern bool ShellExecuteExW(ref SHELLEXECUTEINFOW lpExecInfo);
-
-	[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-	private struct SHELLEXECUTEINFOW {
-		public int cbSize;
-		public uint fMask;
-		public nint hwnd;
-
-		[MarshalAs(UnmanagedType.LPWStr)]
-		public string lpVerb;
-
-		[MarshalAs(UnmanagedType.LPWStr)]
-		public string lpFile;
-
-		[MarshalAs(UnmanagedType.LPWStr)]
-		public string? lpParameters;
-
-		[MarshalAs(UnmanagedType.LPWStr)]
-		public string? lpDirectory;
-
-		public int nShow;
-		public nint hInstApp;
-		public nint lpIDList;
-
-		[MarshalAs(UnmanagedType.LPWStr)]
-		public string? lpClass;
-
-		public nint hkeyClass;
-		public uint dwHotKey;
-		public nint hIcon;
-		public nint hProcess;
-	}
-
-	private const int SW_SHOWNORMAL = 1;
-
 	/// <summary>
-	/// 現在のフォアグラウンドウィンドウと同じモニターでファイルを開く
+	/// Explorerでファイルを選択した状態で表示します
 	/// </summary>
-	public static void ShellExecute(string filePath, string? arguments = null) {
-		var hwnd = GetForegroundWindow();
-
-		var info = new SHELLEXECUTEINFOW {
-			cbSize = Marshal.SizeOf<SHELLEXECUTEINFOW>(),
-			hwnd = hwnd,
-			lpVerb = "open",
-			lpFile = filePath,
-			lpParameters = arguments,
-			nShow = SW_SHOWNORMAL
-		};
-
-		if (!ShellExecuteExW(ref info)) {
-			// フォールバック: 通常のProcess.Startを使用
-			var psi = new ProcessStartInfo { FileName = filePath, UseShellExecute = false };
-			if (arguments != null) {
-				psi.Arguments = arguments;
-			}
-			Process.Start(psi);
-		}
-	}
-
-	/// <summary>
-	/// Explorerでファイルを選択した状態で表示
-	/// </summary>
+	/// <param name="filePath">選択するファイルのフルパス</param>
 	public static void ShowInExplorer(string filePath) {
 		if (string.IsNullOrEmpty(filePath)) {
 			return;
@@ -79,6 +17,27 @@ public static class ShellUtility {
 
 		var psi = new ProcessStartInfo { FileName = "explorer.exe", UseShellExecute = false };
 		psi.ArgumentList.Add("/select," + filePath);
+		Process.Start(psi);
+	}
+
+	/// <summary>
+	/// 現在のフォアグラウンドウィンドウと同じモニターでファイルを開きます
+	/// </summary>
+	/// <param name="filePath">開く対象のファイルパス</param>
+	/// <param name="arguments">プログラムに渡す引数。nullの場合はファイル単体として開きます</param>
+	public static void ShellExecute(string filePath, string? arguments = null) {
+		var psi = new ProcessStartInfo {
+			UseShellExecute = false
+		};
+
+		if (arguments != null) {
+			psi.FileName = filePath;
+			psi.Arguments = arguments;
+		} else {
+			psi.FileName = "explorer.exe";
+			psi.ArgumentList.Add(filePath);
+		}
+
 		Process.Start(psi);
 	}
 }


### PR DESCRIPTION
🎯 **What:** 
`MediaDeck.Common.Utilities.ShellUtility`におけるプロセス起動機能で、OSシェルを介して実行する`ShellExecuteExW` API（`UseShellExecute = true`と同等の挙動）を削除し、直接プロセスを起動する方式（`UseShellExecute = false`）に置き換えました。

⚠️ **Risk:** 
ユーザーが指定したファイルパスや設定された引数が、Windowsのシェル機能によって解釈されてしまうと、意図しない実行ファイルが呼び出されたり、コマンドインジェクション（`&` や `|` の挿入）などの脆弱性が発生する危険性がありました。特に任意のドキュメントファイルを開く機能などにおいて、不正なファイル名が指定された場合に深刻な影響を及ぼす可能性がありました。

🛡️ **Solution:** 
`ShellExecuteExW`（P/Invoke）の使用を完全に廃止し、すべて`Process.Start`（`UseShellExecute = false`）を経由するよう改修しました。
- 実行ファイルとその引数が指定された場合：引数文字列をそのまま渡し、OSシェルによる解釈を防ぎます。
- ドキュメントなど引数なしでファイルを開く場合：システム標準の`explorer.exe`を使用し、`ArgumentList`経由で安全にファイルパスを渡すことで、関連付けられたプログラムで安全にファイルを開けるようにしました。
また、XMLドキュメントコメントの付与（日本語）もあわせて実施しました。
（※Linux CI環境では`explorer.exe`の起動による直接的なテストが困難なため、手動レビューと単体ビルド成功による検証としています）

---
*PR created automatically by Jules for task [11906568888784702266](https://jules.google.com/task/11906568888784702266) started by @xm-i*