### PR TITLE
🧪 RepositorySelectorクラスのユニットテストを追加

### DIFF
--- a/MediaDeck.Core.Tests/Models/Repositories/RepositorySelectorTest.cs
+++ b/MediaDeck.Core.Tests/Models/Repositories/RepositorySelectorTest.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using MediaDeck.Core.Models.Repositories;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace MediaDeck.Core.Tests.Models.Repositories;
+
+/// <summary>
+/// <see cref="RepositorySelector"/> のテストクラスです。
+/// </summary>
+public class RepositorySelectorTest
+{
+    /// <summary>
+    /// コンストラクタがプロパティを正しく初期化することを確認します。
+    /// </summary>
+    [Fact]
+    public void Constructor_InitializesPropertiesCorrectly()
+    {
+        // Arrange
+        // FolderRepositoryは依存関係が多くコンストラクタが重いため、RuntimeHelpersを使用して未初期化インスタンスを生成します。
+        // RepositorySelectorはインスタンスを保持するだけなので、これで十分です。
+        var dummyFolderRepository = RuntimeHelpers.GetUninitializedObject(typeof(FolderRepository)) as FolderRepository;
+
+        // Act
+        var selector = new RepositorySelector(dummyFolderRepository!);
+
+        // Assert
+        selector.Repositories.Should().NotBeNull();
+        selector.Repositories.Should().ContainSingle();
+        selector.Repositories.First().Should().BeSameAs(dummyFolderRepository);
+
+        selector.SelectedRepository.Should().NotBeNull();
+        selector.SelectedRepository.Value.Should().BeSameAs(dummyFolderRepository);
+    }
+}


### PR DESCRIPTION
🎯 **What:** `MediaDeck.Core.Models.Repositories.RepositorySelector` クラスのテストカバレッジが不足していたため、これを補うユニットテストを追加しました。

📊 **Coverage:** コンストラクタが期待通りにプロパティ（`Repositories` 配列および `SelectedRepository` の初期値）を初期化するシナリオ（Happy Path）をテストしています。`FolderRepository` は依存関係が多くコンストラクタが重いため、`RuntimeHelpers.GetUninitializedObject` を使用してテスト時のオーバーヘッドや複雑なモック作成を回避し、テストをシンプルに保ちました。

✨ **Result:** `RepositorySelector` クラスのテストが新たに追加され、コアモデルのコンストラクタによる状態初期化が正しく行われることが保証されるようになり、テストカバレッジが向上しました。

---
*PR created automatically by Jules for task [3909387736445161591](https://jules.google.com/task/3909387736445161591) started by @xm-i*