### PR TITLE
🧪 [testing improvement] Add unit tests for MapPin

### DIFF
--- a/MediaDeck.Core.Tests/MediaDeck.Core.Tests.csproj
+++ b/MediaDeck.Core.Tests/MediaDeck.Core.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/MediaDeck.Core.Tests/Models/Maps/MapPinTests.cs
+++ b/MediaDeck.Core.Tests/Models/Maps/MapPinTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Drawing;
+using FluentAssertions;
+using MediaDeck.Composition.Interfaces.FileTypes.Models;
+using MediaDeck.Composition.Interfaces.Primitives;
+using MediaDeck.Core.Models.Maps;
+using Moq;
+using Xunit;
+using Rectangle = MediaDeck.Core.Models.Maps.Rectangle;
+
+namespace MediaDeck.Core.Tests.Models.Maps;
+
+/// <summary>
+/// <see cref="MapPin"/> のテストクラス
+/// </summary>
+public class MapPinTests {
+    [Fact]
+    public void Constructor_SetsPropertiesCorrectly() {
+        // Arrange
+        var mockFile = new Mock<IFileModel>();
+        var mockLocation = new Mock<IGpsLocation>();
+        mockFile.Setup(f => f.Location).Returns(mockLocation.Object);
+        var rect = new Rectangle(new Point(10, 20), new Size(30, 40));
+
+        // Act
+        var mapPin = new MapPin(mockFile.Object, rect);
+
+        // Assert
+        mapPin.Core.Value.Should().Be(mockFile.Object);
+        mapPin.CoreRectangle.Should().Be(rect);
+        mapPin.Location.Should().Be(mockLocation.Object);
+        mapPin.Items.Should().ContainSingle().Which.Should().Be(mockFile.Object);
+        mapPin.Count.Should().Be(1);
+        mapPin.PinState.Value.Should().Be(PinState.Unselected);
+    }
+
+    [Fact]
+    public void Items_CountChanged_UpdatesCountProperty() {
+        // Arrange
+        var mockFile1 = new Mock<IFileModel>();
+        var mockFile2 = new Mock<IFileModel>();
+        var rect = new Rectangle(new Point(0, 0), new Size(100, 100));
+        var mapPin = new MapPin(mockFile1.Object, rect);
+
+        // Act
+        mapPin.Items.Add(mockFile2.Object);
+
+        // Assert
+        mapPin.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void ToString_ReturnsExpectedFormat() {
+        // Arrange
+        var mockFile = new Mock<IFileModel>();
+        mockFile.Setup(f => f.FilePath).Returns("test/path/to/file.jpg");
+        var rect = new Rectangle(new Point(0, 0), new Size(100, 100));
+        var mapPin = new MapPin(mockFile.Object, rect);
+
+        // Act
+        var result = mapPin.ToString();
+
+        // Assert
+        result.Should().Be("<[MediaDeck.Core.Models.Maps.MapPin] test/path/to/file.jpg>");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing unit tests for the `MapPin` class in `MediaDeck.Core/Models/Maps/MapPin.cs`. It ensures that constructor assignments are working as expected, reactive properties (like `Count`) respond correctly to collection changes, and `ToString` output matches the required formatting wrapper.

📊 **Coverage:** What scenarios are now tested
- Initialization logic verifying correct assignment to properties (`Core.Value`, `Items`, `Location`, `Count`, `CoreRectangle`).
- Event propagation verifying the `Count` property updates when an item is added to the `Items` observable list.
- Format verification of the `ToString` implementation against dummy path data.

✨ **Result:** The improvement in test coverage
Test suite now contains 3 specific unit tests for `MapPin`, fully passing, using Moq and FluentAssertions, to ensure simple mapping errors don't occur when processing items on the map.

*Note:* `Moq` has been added as a dependency to the `MediaDeck.Core.Tests` project to support these tests.

---
*PR created automatically by Jules for task [5698624767391817659](https://jules.google.com/task/5698624767391817659) started by @xm-i*