### PR TITLE
🧪 SortManagerのソートロジックのユニットテストを追加

### DIFF
--- a/MediaDeck.Core.Tests/MediaDeck.Core.Tests.csproj
+++ b/MediaDeck.Core.Tests/MediaDeck.Core.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/MediaDeck.Core.Tests/Models/Files/Sort/SortManagerTests.cs
+++ b/MediaDeck.Core.Tests/Models/Files/Sort/SortManagerTests.cs
@@ -2,6 +2,7 @@ using MediaDeck.Composition.Stores.State.Model;
 using MediaDeck.Composition.Stores.State.Model.Objects;
 using MediaDeck.Core.Models.Files.Sort;
 using MediaDeck.Core.Stores.State;
+using MediaDeck.Composition.Enum;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using ObservableCollections;
@@ -37,6 +38,41 @@ public class SortManagerTests
         mockScope.Setup(x => x.ServiceProvider).Returns(realServiceProvider);
 
         _stateStore = new StateStore(_mockServiceProvider.Object);
+    }
+
+    /// <summary>
+    /// ソートロジックが未ソートのリストを正しい順序でソートすることを確認します。
+    /// </summary>
+    [Fact]
+    public void SortLogic_OrdersUnsortedListCorrectly()
+    {
+        // Arrange
+        var sortManager = new SortManager(_stateStore);
+        sortManager.AddCondition();
+        var sortObject = sortManager.SortConditions.Last();
+
+        var item = sortObject.AddSortItemObject();
+        item.SortItemKey = SortItemKey.FilePath;
+        item.Direction = System.ComponentModel.ListSortDirection.Ascending;
+
+        _stateStore.State.SearchState.CurrentSortCondition.Value = sortObject.Id;
+        _stateStore.State.SearchState.SortDirection.Value = System.ComponentModel.ListSortDirection.Ascending;
+
+        var selector = new SortSelector(_stateStore.State);
+        var unsortedList = new[]
+        {
+            new TestFileModel { FilePath = "FileC.txt" },
+            new TestFileModel { FilePath = "FileA.txt" },
+            new TestFileModel { FilePath = "FileB.txt" }
+        };
+
+        // Act
+        var result = selector.SetSortConditions(unsortedList).Cast<TestFileModel>().ToList();
+
+        // Assert
+        Assert.Equal("FileA.txt", result[0].FilePath);
+        Assert.Equal("FileB.txt", result[1].FilePath);
+        Assert.Equal("FileC.txt", result[2].FilePath);
     }
 
     /// <summary>


### PR DESCRIPTION
🎯 **What:** `SortManager` (および関連する `SortSelector`) のソートロジックのテストカバレッジが不足していたため、未ソートのリストを与えて期待通りの順序でソートされることをアサートするテストを追加しました。

📊 **Coverage:**
- `SortManager` を介してソート条件を追加・設定するシナリオを追加しました。
- `SortSelector` がその条件を用いてリストを正しく並べ替えること（FilePathの昇順ソートなど）を確認するテスト(`SortLogic_OrdersUnsortedListCorrectly`)が追加されました。
- テストに必要なモック機能の提供として `Moq` ライブラリの依存関係を `MediaDeck.Core.Tests.csproj` に追加しました。

✨ **Result:** 
- ソートロジック全体の機能がより確実に検証され、リファクタリングなどによるエンバグを防止するためのセーフティネットが強化されました。
- ローカルテストの実行と自動レビューをパスしました。

---
*PR created automatically by Jules for task [13487965876380991211](https://jules.google.com/task/13487965876380991211) started by @xm-i*