### PR TITLE
🧹 [code health] Remove duplicate ImageDescription assignment in Jpeg

### DIFF
--- a/MediaDeck.FileTypes/Image/Utils/Formats/Jpeg.cs
+++ b/MediaDeck.FileTypes/Image/Utils/Formats/Jpeg.cs
@@ -51,7 +51,6 @@ internal class Jpeg : ImageBase {
 		var subIfd = this._reader.FirstOrDefault(x => x is ExifSubIfdDirectory);
 
 		metadata.ImageDescription = this.GetString(ifd0, ExifDirectoryBase.TagImageDescription);
-		metadata.ImageDescription = this.GetString(ifd0, ExifDirectoryBase.TagImageDescription);
 		metadata.Make = this.GetString(ifd0, ExifDirectoryBase.TagMake);
 		metadata.Model = this.GetString(ifd0, ExifDirectoryBase.TagModel);
 		metadata.Orientation = this.GetShort(ifd0, ExifDirectoryBase.TagOrientation);


### PR DESCRIPTION
🎯 **What:** Jpegメタデータ処理における `ImageDescription` プロパティの重複した代入を削除しました。
💡 **Why:** 同じ値の代入が2行続いており、コードの可読性を下げる無駄な処理だったためです。
✅ **Verification:** プロジェクトのビルドが成功し、`MediaDeck.Core.Tests` を実行して既存のテストがパスすることを確認しました。
✨ **Result:** コードがよりクリーンになり、保守性が向上しました。機能への影響はありません。

---
*PR created automatically by Jules for task [16802334270213653139](https://jules.google.com/task/16802334270213653139) started by @xm-i*