### PR TITLE
🧪 ConfigStoreのエラーハンドリングに対するテスト追加

### DIFF
--- a/MediaDeck.Core.Tests/Stores/Config/ConfigStoreTests.cs
+++ b/MediaDeck.Core.Tests/Stores/Config/ConfigStoreTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using MediaDeck.Composition.Constants;
+using MediaDeck.Composition.Stores.Config.Model;
+using MediaDeck.Core.Stores.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace MediaDeck.Core.Tests.Stores.Config;
+
+public class ConfigStoreTests : IDisposable
+{
+    private readonly string _configFilePath;
+    private readonly string _backupConfigFilePath;
+    private readonly bool _hadExistingConfig;
+
+    public ConfigStoreTests()
+    {
+        _configFilePath = FilePathConstants.ConfigFilePath;
+        _backupConfigFilePath = _configFilePath + ".bak";
+
+        _hadExistingConfig = File.Exists(_configFilePath);
+        if (_hadExistingConfig)
+        {
+            File.Move(_configFilePath, _backupConfigFilePath);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_configFilePath))
+        {
+            File.Delete(_configFilePath);
+        }
+
+        if (_hadExistingConfig)
+        {
+            File.Move(_backupConfigFilePath, _configFilePath);
+        }
+    }
+
+    [Fact]
+    public void Load_ThrowsException_CreatesDefaultConfig()
+    {
+        // Arrange
+        Directory.CreateDirectory(Path.GetDirectoryName(_configFilePath)!);
+        // Write invalid JSON to force JsonSerializer.Deserialize to throw JsonException
+        File.WriteAllText(_configFilePath, "{ invalid json }");
+
+        var services = new ServiceCollection();
+        var mockConfig = (ConfigModel)RuntimeHelpers.GetUninitializedObject(typeof(ConfigModel));
+        services.AddSingleton(mockConfig);
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Act
+        var store = new ConfigStore(serviceProvider); // Load is called in constructor
+
+        // Assert
+        store.Config.ShouldNotBeNull();
+        store.Config.ShouldBeSameAs(mockConfig); // Should fallback to DI
+    }
+
+    [Fact]
+    public void Save_ThrowsException_DoesNotCrash()
+    {
+        // Arrange
+        Directory.CreateDirectory(Path.GetDirectoryName(_configFilePath)!);
+        // Lock the file to force an IOException when Save tries to write to it
+        using var fs = new FileStream(_configFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+
+        var services = new ServiceCollection();
+        var mockConfig = (ConfigModel)RuntimeHelpers.GetUninitializedObject(typeof(ConfigModel));
+        services.AddSingleton(mockConfig);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var store = new ConfigStore(serviceProvider);
+
+        // Act & Assert
+        // Should not throw
+        Should.NotThrow(() => store.Save());
+    }
+}


### PR DESCRIPTION
🎯 **What:** ConfigStoreのLoadおよびSaveメソッドにおける例外ハンドリング（TODO: 失敗通知となっている箇所）が想定通りに動作するかを検証するテストが欠落していたため、テストを追加しました。

📊 **Coverage:** 
- `Load_ThrowsException_CreatesDefaultConfig`: `FilePathConstants.ConfigFilePath`に不正なJSONを書き込んだ際、`JsonSerializer.Deserialize`で発生する例外を正しくキャッチし、DIコンテナ経由でフォールバックとして新しい`ConfigModel`が生成されることを確認。
- `Save_ThrowsException_DoesNotCrash`: ファイルロックによる`IOException`発生時でも、`Save`メソッドが例外を外に投げずにクラッシュを回避することを確認。

✨ **Result:** ConfigStoreの例外時における安全な動作（フォールバックおよびクラッシュ回避）がテストによって保証されるようになりました。

---
*PR created automatically by Jules for task [158197548263420717](https://jules.google.com/task/158197548263420717) started by @xm-i*