### PR TITLE
🧹 [Code Health] Document empty virtual hook methods OnViewModelChanged

### DIFF
--- a/MediaDeck.FileTypes/Base/Views/UserControlBase.cs
+++ b/MediaDeck.FileTypes/Base/Views/UserControlBase.cs
@@ -16,5 +16,13 @@ internal abstract class UserControlBase<T> : UserControl where T : class {
 		};
 	}
 
-	protected virtual void OnViewModelChanged(T? oldViewModel, T? newViewModel) { }
+	/// <summary>
+	/// ViewModel が変更されたときに呼び出されます。派生クラスでオーバーライドして処理を追加します。
+	/// </summary>
+	/// <param name="oldViewModel">変更前の ViewModel。</param>
+	/// <param name="newViewModel">変更後の ViewModel。</param>
+	protected virtual void OnViewModelChanged(T? oldViewModel, T? newViewModel)
+	{
+		// 派生クラスでのオーバーライド用のフックメソッド
+	}
 }

--- a/MediaDeck/Views/UserControlBase.cs
+++ b/MediaDeck/Views/UserControlBase.cs
@@ -16,5 +16,13 @@ public abstract class UserControlBase<T> : UserControl where T : class {
 		};
 	}
 
-	protected virtual void OnViewModelChanged(T? oldViewModel, T? newViewModel) { }
+	/// <summary>
+	/// ViewModel が変更されたときに呼び出されます。派生クラスでオーバーライドして処理を追加します。
+	/// </summary>
+	/// <param name="oldViewModel">変更前の ViewModel。</param>
+	/// <param name="newViewModel">変更後の ViewModel。</param>
+	protected virtual void OnViewModelChanged(T? oldViewModel, T? newViewModel)
+	{
+		// 派生クラスでのオーバーライド用のフックメソッド
+	}
 }


### PR DESCRIPTION
🎯 **What:** Added XML documentation and internal comments to the empty virtual `OnViewModelChanged` methods in both `MediaDeck/Views/UserControlBase.cs` and `MediaDeck.FileTypes/Base/Views/UserControlBase.cs`.
💡 **Why:** Explicitly marks these methods as hook methods intended to be overridden by derived classes, preventing them from being mistakenly identified as dead code by static analysis or developers. This clarifies the intent of the API to future maintainers.
✅ **Verification:** Verified by compiling the solution and running the unit tests with `dotnet test /p:EnableWindowsTargeting=true`. Tests continue to pass.
✨ **Result:** Enhanced clarity and maintainability for base classes used in the UI layer.

---
*PR created automatically by Jules for task [5426383907010294407](https://jules.google.com/task/5426383907010294407) started by @xm-i*