### PR TITLE
🧹 [Code Health] Remove duplicate ImageDescription assignment in image metadata

### DIFF
--- a/MediaDeck.FileTypes/Image/Utils/Formats/Heif.cs
+++ b/MediaDeck.FileTypes/Image/Utils/Formats/Heif.cs
@@ -50,7 +50,6 @@ internal class Heif : ImageBase {
 		var subIfd = this._reader.FirstOrDefault(x => x is ExifSubIfdDirectory);
 
 		metadata.ImageDescription = this.GetString(ifd0, ExifDirectoryBase.TagImageDescription);
-		metadata.ImageDescription = this.GetString(ifd0, ExifDirectoryBase.TagImageDescription);
 		metadata.Make = this.GetString(ifd0, ExifDirectoryBase.TagMake);
 		metadata.Model = this.GetString(ifd0, ExifDirectoryBase.TagModel);
 		metadata.Orientation = this.GetShort(ifd0, ExifDirectoryBase.TagOrientation);

--- a/MediaDeck.FileTypes/Image/Utils/Formats/Jpeg.cs
+++ b/MediaDeck.FileTypes/Image/Utils/Formats/Jpeg.cs
@@ -51,7 +51,6 @@ internal class Jpeg : ImageBase {
 		var subIfd = this._reader.FirstOrDefault(x => x is ExifSubIfdDirectory);
 
 		metadata.ImageDescription = this.GetString(ifd0, ExifDirectoryBase.TagImageDescription);
-		metadata.ImageDescription = this.GetString(ifd0, ExifDirectoryBase.TagImageDescription);
 		metadata.Make = this.GetString(ifd0, ExifDirectoryBase.TagMake);
 		metadata.Model = this.GetString(ifd0, ExifDirectoryBase.TagModel);
 		metadata.Orientation = this.GetShort(ifd0, ExifDirectoryBase.TagOrientation);


### PR DESCRIPTION
🎯 What: Removed duplicate metadata.ImageDescription assignments in Heif.cs and Jpeg.cs
💡 Why: Duplicate assignments of the same exact value simply clutter the code without adding functionality or differing results. Removing them improves code readability and maintainability.
✅ Verification: Ran unit tests via dotnet test with EnableWindowsTargeting enabled, ensuring regressions were not introduced. Checked that no other data assignments were accidentally affected.
✨ Result: Cleaned up code health in the image metadata parsing format components.

---
*PR created automatically by Jules for task [1349236664631608813](https://jules.google.com/task/1349236664631608813) started by @xm-i*