### PR TITLE
🧪 テスト改善: FilterItemObjectJsonConverter.Read の例外パスをテスト

### DIFF
--- a/MediaDeck.Core.Tests/Stores/Converters/FilterItemObjectJsonConverterTests.cs
+++ b/MediaDeck.Core.Tests/Stores/Converters/FilterItemObjectJsonConverterTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Text.Json;
+using MediaDeck.Composition.Interfaces.Files;
+using MediaDeck.Core.Stores.Converters;
+using Xunit;
+
+namespace MediaDeck.Core.Tests.Stores.Converters;
+
+public class FilterItemObjectJsonConverterTests
+{
+    private class TestContainer
+    {
+        public IFilterItemObject? Item { get; set; }
+    }
+
+    [Fact]
+    public void Read_InvalidType_ThrowsException()
+    {
+        // Arrange
+        // Give it valid XAML but of a type that does not implement IFilterItemObject.
+        var json = "{\"Item\":\"<Int32 xmlns=\\\"clr-namespace:System;assembly=System.Runtime\\\">42</Int32>\"}";
+        var options = new JsonSerializerOptions
+        {
+            Converters = { new FilterItemObjectJsonConverter() }
+        };
+
+        // Act & Assert
+        var exception = Assert.Throws<Exception>(() => JsonSerializer.Deserialize<TestContainer>(json, options));
+        Assert.Equal("Failed to deserialize IFilterItemObject from XAML.", exception.Message);
+    }
+
+    [Fact]
+    public void Read_InvalidXaml_ThrowsException()
+    {
+        // Arrange
+        // Invalid XAML, which throws during XamlServices.Load
+        var json = "{\"Item\":\"<InvalidXaml>not a filter item</InvalidXaml>\"}";
+        var options = new JsonSerializerOptions
+        {
+            Converters = { new FilterItemObjectJsonConverter() }
+        };
+
+        // Act & Assert
+        var exception = Record.Exception(() => JsonSerializer.Deserialize<TestContainer>(json, options));
+        Assert.NotNull(exception);
+    }
+}


### PR DESCRIPTION
🎯 **What:** `FilterItemObjectJsonConverter.Read`メソッドの例外パスがテストされていなかったため、テストカバレッジを追加しました。
📊 **Coverage:** 
- 有効なXAMLであっても予期しない型（例：`<Int32>`）が渡された場合、`is not IFilterItemObject`のチェックで期待通りの例外（`"Failed to deserialize IFilterItemObject from XAML."`）がスローされることをテストしました。
- 無効なXAMLが渡された場合、`XamlServices.Load`側で`XamlObjectWriterException`などの例外が適切に発生することをテストしました。
✨ **Result:** 該当部分のテストカバレッジが向上し、デシリアライズ時のエラーハンドリングの安全性が保証されるようになりました。

---
*PR created automatically by Jules for task [7742792391840404404](https://jules.google.com/task/7742792391840404404) started by @xm-i*