### PR TITLE
🧹 [Code Health] ComparableSizeのバックエンドフィールドをfieldキーワードにリファクタリング

### DIFF
--- a/MediaDeck.Composition/Objects/ComparableSize.cs
+++ b/MediaDeck.Composition/Objects/ComparableSize.cs
@@ -4,18 +4,13 @@ namespace MediaDeck.Composition.Objects;
 /// 比較可能なサイズ構造体
 /// </summary>
 public struct ComparableSize : IComparable<ComparableSize>, IComparable {
-	private double _width;
-	private double _height;
-
 	/// <summary>
 	/// 幅
 	/// </summary>
 	public double Width {
-		get {
-			return this._width;
-		}
+		get;
 		set {
-			this._width = value;
+			field = value;
 			this.UpdateArea();
 		}
 	}
@@ -24,11 +19,9 @@ public struct ComparableSize : IComparable<ComparableSize>, IComparable {
 	/// 高さ
 	/// </summary>
 	public double Height {
-		get {
-			return this._height;
-		}
+		get;
 		set {
-			this._height = value;
+			field = value;
 			this.UpdateArea();
 		}
 	}


### PR DESCRIPTION
## 🎯 What
`MediaDeck.Composition/Objects/ComparableSize.cs` に存在した、`_width` と `_height` という明示的なプライベートフィールドを削除し、代わりにC# 13(preview) の `field` キーワードを使用してリファクタリングしました。

## 💡 Why
- `Width` と `Height` プロパティのsetterで副作用（`UpdateArea()` の呼び出し）があるため、純粋な自動実装プロパティ（auto-property）にすることはできません。
- 代わりに、C#のプレビュー機能である `field` キーワードを使うことで、手動でのフィールド定義を省き、コードのボイラープレートを減らして可読性を向上させることができます。

## ✅ Verification
- `export EnableWindowsTargeting=true && dotnet format MediaDeck.slnx` によるフォーマット検証を実施しました。
- `dotnet test /p:EnableWindowsTargeting=true` による全体のテストが通過することを確認し、リファクタリングによる副作用がないことを確認しました。

## ✨ Result
明示的なフィールド宣言が削除され、コードが簡潔でメンテナンスしやすくなりました。挙動の変更はありません。

---
*PR created automatically by Jules for task [8818474799200585935](https://jules.google.com/task/8818474799200585935) started by @xm-i*