### PR TITLE
🧪 ConfigStoreの保存失敗時の例外ハンドリングテストを改善

### DIFF
--- a/MediaDeck.Core.Tests/Stores/Config/ConfigStoreTests.cs
+++ b/MediaDeck.Core.Tests/Stores/Config/ConfigStoreTests.cs
@@ -12,36 +12,45 @@ using Xunit;
 namespace MediaDeck.Core.Tests.Stores.Config;
 
 public class ConfigStoreTests : IDisposable {
-	private readonly string _configFilePath;
-	private readonly string _backupConfigFilePath;
-	private readonly bool _hadExistingConfig;
+	private readonly string _tempDirectory;
+	private readonly string _testConfigFilePath;
 
-	public ConfigStoreTests() {
-		this._configFilePath = FilePathConstants.ConfigFilePath;
-		this._backupConfigFilePath = this._configFilePath + ".bak";
+	// We create a testable wrapper to override the virtual ConfigFilePath property
+	private class TestableConfigStore : ConfigStore {
+		// Use a static property to bypass the "virtual member call in constructor" issue
+		// so that the path is available when the base constructor calls Load().
+		public static string TestPath { get; set; } = string.Empty;
 
-		this._hadExistingConfig = File.Exists(this._configFilePath);
-		if (this._hadExistingConfig) {
-			File.Move(this._configFilePath, this._backupConfigFilePath);
+		protected override string ConfigFilePath {
+			get {
+				return TestPath;
+			}
+		}
+
+		public TestableConfigStore(IServiceProvider service) : base(service) {
 		}
 	}
 
-	public void Dispose() {
-		if (File.Exists(this._configFilePath)) {
-			File.Delete(this._configFilePath);
-		}
+	public ConfigStoreTests() {
+		this._tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+		Directory.CreateDirectory(this._tempDirectory);
+		this._testConfigFilePath = Path.Combine(this._tempDirectory, "MediaDeck.config");
 
-		if (this._hadExistingConfig) {
-			File.Move(this._backupConfigFilePath, this._configFilePath);
+		TestableConfigStore.TestPath = this._testConfigFilePath;
+	}
+
+	public void Dispose() {
+		if (Directory.Exists(this._tempDirectory)) {
+			Directory.Delete(this._tempDirectory, true);
 		}
 	}
 
 	[Fact]
 	public void Load_ThrowsException_CreatesDefaultConfig() {
 		// Arrange
-		Directory.CreateDirectory(Path.GetDirectoryName(this._configFilePath)!);
+		Directory.CreateDirectory(Path.GetDirectoryName(this._testConfigFilePath)!);
 		// Write invalid JSON to force JsonSerializer.Deserialize to throw JsonException
-		File.WriteAllText(this._configFilePath, "{ invalid json }");
+		File.WriteAllText(this._testConfigFilePath, "{ invalid json }");
 
 		var services = new ServiceCollection();
 		var mockConfig = (ConfigModel)RuntimeHelpers.GetUninitializedObject(typeof(ConfigModel));
@@ -49,7 +58,7 @@ public class ConfigStoreTests : IDisposable {
 		var serviceProvider = services.BuildServiceProvider();
 
 		// Act
-		var store = new ConfigStore(serviceProvider); // Load is called in constructor
+		var store = new TestableConfigStore(serviceProvider); // Load is called in constructor
 
 		// Assert
 		store.Config.ShouldNotBeNull();
@@ -59,19 +68,37 @@ public class ConfigStoreTests : IDisposable {
 	[Fact]
 	public void Save_ThrowsException_DoesNotCrash() {
 		// Arrange
-		Directory.CreateDirectory(Path.GetDirectoryName(this._configFilePath)!);
+		Directory.CreateDirectory(Path.GetDirectoryName(this._testConfigFilePath)!);
 		// Lock the file to force an IOException when Save tries to write to it
-		using var fs = new FileStream(this._configFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+		using var fs = new FileStream(this._testConfigFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
 
 		var services = new ServiceCollection();
 		var mockConfig = (ConfigModel)RuntimeHelpers.GetUninitializedObject(typeof(ConfigModel));
 		services.AddSingleton(mockConfig);
 		var serviceProvider = services.BuildServiceProvider();
 
-		var store = new ConfigStore(serviceProvider);
+		var store = new TestableConfigStore(serviceProvider);
 
 		// Act & Assert
 		// Should not throw
+		Should.NotThrow(() => store.Save());
+	}
+
+	[Fact]
+	public void Save_WithInvalidFilePath_DoesNotThrow() {
+		// Arrange
+		TestableConfigStore.TestPath = string.Empty;
+
+		var services = new ServiceCollection();
+		var mockConfig = (ConfigModel)RuntimeHelpers.GetUninitializedObject(typeof(ConfigModel));
+		services.AddSingleton(mockConfig);
+		var serviceProvider = services.BuildServiceProvider();
+
+		var store = new TestableConfigStore(serviceProvider);
+
+		// Act & Assert
+		// Calling Save with an empty file path will cause an exception in Path.GetDirectoryName or File.WriteAllText
+		// The test ensures the exception is caught and does not crash the application
 		Should.NotThrow(() => store.Save());
 	}
 }

--- a/MediaDeck.Core/Stores/Config/ConfigStore.cs
+++ b/MediaDeck.Core/Stores/Config/ConfigStore.cs
@@ -20,6 +20,13 @@ public class ConfigStore {
 		private set;
 	}
 
+	// Protected property to allow overriding the file path during testing.
+	protected virtual string ConfigFilePath {
+		get {
+			return FilePathConstants.ConfigFilePath;
+		}
+	}
+
 	public ConfigStore(IServiceProvider service) {
 		this.ScopedService = service;
 		this.Load();
@@ -32,8 +39,8 @@ public class ConfigStore {
 	public void Load() {
 		var scope = this.ScopedService.CreateScope();
 		try {
-			if (File.Exists(FilePathConstants.ConfigFilePath)) {
-				var json = File.ReadAllText(FilePathConstants.ConfigFilePath);
+			if (File.Exists(this.ConfigFilePath)) {
+				var json = File.ReadAllText(this.ConfigFilePath);
 				var loaded = JsonSerializer.Deserialize(json, ConfigJsonSerializerContext.Default.ConfigModelForJson);
 				if (loaded != null) {
 					this.Config = ConfigModelForJson.CreateModel(loaded, scope.ServiceProvider);
@@ -51,11 +58,11 @@ public class ConfigStore {
 	/// </summary>
 	public void Save() {
 		try {
-			Directory.CreateDirectory(Path.GetDirectoryName(FilePathConstants.ConfigFilePath)!);
+			Directory.CreateDirectory(Path.GetDirectoryName(this.ConfigFilePath)!);
 
 			var jsonDto = ConfigModelForJson.CreateJson(this.Config);
 			var json = JsonSerializer.Serialize(jsonDto, ConfigJsonSerializerContext.Default.ConfigModelForJson);
-			File.WriteAllText(FilePathConstants.ConfigFilePath, json);
+			File.WriteAllText(this.ConfigFilePath, json);
 		} catch (Exception) {
 			// TODO: 失敗通知
 		}


### PR DESCRIPTION
🎯 **What:** 
`ConfigStore.Save()`メソッド内でファイル書き込み時に例外が発生するパス（エラー通知等に繋がる部分）が未テストであったため、このパスをカバーするテストを追加・改善しました。同時にテストが開発者の実環境の`MediaDeck.config`を破壊しないように、安全な一時ディレクトリを用いた構成にリファクタリングしました。

📊 **Coverage:** 
- `ConfigStore.Save()`実行時にファイルがロックされていることによる例外発生パス（既存テストの改善）
- `ConfigStore.Save()`実行時にファイルパスが空文字列等の不正な値であった場合の例外発生パス（新規追加）
- `ConfigStore.Load()`実行時の例外発生およびデフォルト設定へのフォールバック（既存テストの改善）

✨ **Result:** 
`ConfigStore`に対するテストの信頼性と安全性が向上しました。例外発生時でもクラッシュせずに例外がハンドリングされることがテストケースによって担保されるようになりました。また、テスト実行時にグローバルな状態を汚染しない健全なテスト構造になりました。

---
*PR created automatically by Jules for task [17177162045701075698](https://jules.google.com/task/17177162045701075698) started by @xm-i*