### PR TITLE
🧹 [code health] Use specific exception in VideoFileOperator

### DIFF
--- a/MediaDeck.FileTypes/Video/Models/VideoFileOperator.cs
+++ b/MediaDeck.FileTypes/Video/Models/VideoFileOperator.cs
@@ -44,7 +44,7 @@ internal partial class VideoFileOperator : BaseFileOperator {
 		var thumbPath = this._filePathService.GetThumbnailAbsoluteFilePath(thumbRelativePath);
 		try {
 			if (metadata.PrimaryVideoStream is not { } videoStream) {
-				throw new Exception("PrimaryVideoStream is null");
+				throw new InvalidOperationException("PrimaryVideoStream is null");
 			}
 			var image = this.CreateThumbnail(filePath, videoStream.Width, videoStream.Height, 300, 300, metadata.Duration / 5);
 			new FileInfo(thumbPath).Directory?.Create();
@@ -99,7 +99,7 @@ internal partial class VideoFileOperator : BaseFileOperator {
 	internal byte[] CreateThumbnail(IFileModel fileModel, int width, int height, TimeSpan time) {
 		var metadata = FFProbe.Analyse(fileModel.FilePath);
 		if (metadata.PrimaryVideoStream is not { } videoStream) {
-			throw new Exception("PrimaryVideoStream is null");
+			throw new InvalidOperationException("PrimaryVideoStream is null");
 		}
 		return this.CreateThumbnail(fileModel.FilePath, videoStream.Width, videoStream.Height, width, height, time);
 	}


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Replaced generic `System.Exception` with `System.InvalidOperationException` in `VideoFileOperator.cs`.
- Applied changes to both `RegisterFileAsync` and `CreateThumbnail` methods for consistency.

💡 **Why:** How this improves maintainability
- Provides better clarity on the nature of the error.
- Follows C# best practices for exception handling.
- Improves code readability and maintainability by being more specific about the error state (invalid operation due to missing primary video stream).

✅ **Verification:** How you confirmed the change is safe
- Verified file content after modification.
- Successfully passed code review which confirmed the logic and safety.
- Note: Full build and test suite execution timed out due to sandbox environment constraints, but the change is a low-risk exception type replacement.

✨ **Result:** The improvement achieved
- Improved code health and compliance with best practices.
- Consistent exception throwing pattern within the class.

---
*PR created automatically by Jules for task [1473842831278600773](https://jules.google.com/task/1473842831278600773) started by @xm-i*